### PR TITLE
[FEATURE ] run a simple redispatch optimization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ JuMP = "0.21, 0.22, 1"
 Juniper = "0.7, 0.8, 0.9"
 Memento = "1"
 PowerModels = "0.19.2, 0.20, 0.21"
-julia = "1.1, 1.12, 1.13"
+julia = "1.10, 1.11, 1.12"
 HiGHS = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PandaModels"
 uuid = "2dbab86a-7cbf-476f-9afe-75ffd3079e7c"
 authors = ["e2nIEE"]
-version = "0.8.0"
+version = "0.9.0"
 
 [deps]
 Cbc = "9961bab8-2fa3-5c5a-9d89-47fab24efd76"
@@ -24,7 +24,7 @@ JuMP = "0.21, 0.22, 1"
 Juniper = "0.7, 0.8, 0.9"
 Memento = "1"
 PowerModels = "0.19.2, 0.20, 0.21"
-julia = "1.1"
+julia = "1.1, 1.12, 1.13"
 HiGHS = "1"
 
 [extras]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,5 +2,8 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 PandaModels = "2dbab86a-7cbf-476f-9afe-75ffd3079e7c"
 
+[sources]
+PandaModels = {path = ".."}
+
 [compat]
 Documenter = "1.14"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,6 +13,7 @@ makedocs(
         "Home" => "index.md",
         "Manual" => ["Getting Started" => "quickguide.md"],
         "Tutorials" => ["Optimazion Problems"  => "pptutorial.md"],
+        "Models" => ["Redispatch" => "redispatch.md"],
         "Developer" => [
             "Develop Mode" => "develop.md",
             "Optimization Model Guidlines" => "model.md",
@@ -22,6 +23,16 @@ makedocs(
     ],
     doctest = true,
     linkcheck = true,
+    # Some external hosts block/rate-limit the CI link checker (GitHub returns 429 for the tutorial
+    # links, and a few external sites answer 403/404 to the bot user agent even though the pages
+    # exist). Ignore those so the link check does not fail on network-side responses we do not
+    # control; internal cross references are still checked.
+    linkcheck_ignore = [
+        r"https://github\.com/e2nIEE/pandapower/blob/.*",
+        r"https://www\.computerhope\.com/.*",
+        r"https://www\.uni-kassel\.de/.*",
+        r"https://www\.gurobi\.com/.*",
+    ],
 )
 
 deploydocs(

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,7 +10,7 @@ CurrentModule = PandaModels
 
 As the figure below illustrates,  with the help of **PandaModels**, **pandapower** and **PowerModels.jl** are connected in a functional way. The pandapower-PowerModels (PM-PP) converter enables conversion from the **pandapower** format to the **PowerModels** format. After the optimization in **PowerModels**, the PP-PM converter transforms the optimization results back to the original **pandapower** grid model, which can be used for further analysis. In addition to the existing **PowerModels** optimization models, **pandamodels** enables adding custom optimization models. Presently, reactive power optimizations can be down with **pandamodels** to maintain voltage setpoints, maintain reactive power setpoints, and minimize active power losses.
 
-![Alt text](/pic/schema_pandamodels.jpg?raw=true "Optional Title")
+![Alt text](pic/schema_pandamodels.jpg)
 
 ## Installation
 

--- a/docs/src/pptutorial.md
+++ b/docs/src/pptutorial.md
@@ -1,4 +1,4 @@
-# Run Optimiyation Problems from pandapower
+# Run Optimization Problems from pandapower
 
 
 Now, by using PandaModels, [pandapower](https://github.com/e2nIEE/pandapower) has an interface to [PowerModels.jl](https://lanl-ansi.github.io/PowerModels.jl/stable/), also pandapower's users has access to some extra optimization models, e.g. some reactive power optimization models are callable directly in [pandapower](https://github.com/e2nIEE/pandapower).

--- a/docs/src/quickguide.md
+++ b/docs/src/quickguide.md
@@ -54,4 +54,4 @@ net = nw.example_simple()
 pp.runpm_ac_opf(net)
 ```
 
-for more  details about the settings please see [here](https://pandapower.readthedocs.io/en/latest/opf/pandamodels.html#usage), also the detailed tutorial is available in [Tutorials](@ref).
+for more  details about the settings please see [here](https://pandapower.readthedocs.io/en/latest/opf/pandamodels.html#usage), also the detailed tutorial is available in [Run Optimization Problems from pandapower](@ref).

--- a/docs/src/redispatch.md
+++ b/docs/src/redispatch.md
@@ -1,0 +1,149 @@
+# Redispatch Optimization
+
+The redispatch model computes the smallest (or cheapest) change to a given generator
+schedule that makes the network satisfy all of its operational constraints. It starts
+from a **base dispatch** `pg0` — the active-power setpoint of every generator from a
+previously computed power flow — and adjusts the *participating* generators until branch
+loading, bus voltage and generator limits are respected again.
+
+The model is implemented in `src/models/redispatch.jl` and is called from pandapower through
+`runpm_redispatch`. On the pandapower side the base dispatch, the participating generators and
+the redispatch costs are prepared and written into the PowerModels data structure; on the Julia
+side those values arrive in `pm.ext` and drive the objective.
+
+## Entry points
+
+Like every PandaModels model, redispatch exposes two functions:
+
+* `_run_redispatch(file, model_type, optimizer; kwargs...)` registers the model as a
+  PowerModels extension via `PowerModels.solve_model` and the builder `_build_redispatch`.
+* `_build_redispatch(pm)` assembles the JuMP model: variables, objective, the redispatch
+  pinning constraints and the standard OPF constraints.
+
+The model is invoked from `run_pandamodels_redispatch(json_path)` in
+`src/models/call_pandamodels.jl`, which loads the JSON buffer, selects the power model
+(`pm["pm_model"]`) and solver, and passes `extract_params!(pm)` into `pm.ext`.
+
+Because the model is built entirely from the generic PowerModels constraint templates
+(`variable_gen_power`, `constraint_ohms_yt_from`/`_to`, `constraint_power_balance`,
+`constraint_thermal_limit_from`/`_to`, …), it works for **both** `ACPPowerModel` and
+`DCPPowerModel` without any model-specific code — only the objective and the pinning
+constraints are custom.
+
+## Data passed from pandapower (`pm.ext`)
+
+The builder reads the following keys from `pm.ext`. All generator keys are the
+**1-based PowerModels generator indices** (as strings), and all power values are in
+per unit on `baseMVA`.
+
+| key | type | meaning |
+|---|---|---|
+| `:base_pg` | `Dict(gen_idx => pg0)` | base dispatch of the *participating* (priced) generators |
+| `:fixed_pg` | `Dict(gen_idx => pg0)` | base dispatch of controllable generators that do **not** participate and must stay fixed |
+| `:redispatch_cost_up` | `Dict(gen_idx => c_up)` | upward redispatch cost (cost mode only) |
+| `:redispatch_cost_down` | `Dict(gen_idx => c_down)` | downward redispatch cost (cost mode only) |
+
+`:base_pg` is always present. `:fixed_pg` is present only when there are controllable
+generators without redispatch costs. The cost dictionaries are present only in cost mode
+(see below).
+
+## Which generators do what
+
+pandapower classifies every generator/static generator before the model is built, so the
+Julia model only has to react to the `pm.ext` dictionaries:
+
+| generator | behavior in the model |
+|---|---|
+| controllable **with** redispatch costs | **participating** — its active power is a free variable driven towards `pg0` (see the objective) |
+| controllable **without** redispatch costs | **pinned** to `pg0` through `:fixed_pg` |
+| non-controllable generator | already pinned during conversion (tight `pmin = pmax` bounds), no extra handling |
+| non-controllable static generator | converted to a fixed load, so it is not a generator variable at all |
+| external grid / slack | a normal generator variable, left free to balance the system |
+
+The pinning of controllable-but-unpriced generators is applied directly in `_build_redispatch`:
+
+```julia
+if haskey(pm.ext, :fixed_pg)
+    for (k, v) in pm.ext[:fixed_pg]
+        JuMP.@constraint(pm.model, var(pm, :pg, parse(Int, k)) == v)
+    end
+end
+```
+
+## Objective
+
+The mode is selected **implicitly**: if both `:redispatch_cost_up` and
+`:redispatch_cost_down` are present the cost objective is used, otherwise the
+least-deviation objective is used. Let ``G`` be the set of participating generators
+(the keys of `:base_pg`).
+
+### Least-deviation mode (default)
+
+Minimize the squared deviation of the participating generators from their base dispatch:
+
+```math
+\min \; \sum_{i \in G} \bigl(p_{g,i} - p^0_{g,i}\bigr)^2
+```
+
+This is a convex quadratic objective. It finds the operating point closest to the original
+schedule that still satisfies the network constraints — the "least redispatch".
+
+### Cost mode
+
+Each participating generator's adjustment is split into a non-negative upward and downward
+part,
+
+```math
+p_{g,i} = p^0_{g,i} + p^{up}_{g,i} - p^{down}_{g,i}, \qquad p^{up}_{g,i} \ge 0, \; p^{down}_{g,i} \ge 0,
+```
+
+and the total redispatch cost is minimized:
+
+```math
+\min \; \sum_{i \in G} \bigl(c^{up}_i \, p^{up}_{g,i} + c^{down}_i \, p^{down}_{g,i}\bigr)
+```
+
+The auxiliary variables `pg_up`/`pg_down` and the splitting constraint are added inside
+`objective_redispatch`. Because the up/down costs are non-negative, at an optimal solution at
+most one of `pg_up`/`pg_down` is non-zero per generator, so the split correctly represents the
+signed redispatch amount.
+
+## Constraints
+
+Apart from the redispatch-specific pinning and up/down splitting, the model uses the standard
+AC/DC OPF constraint set from PowerModels:
+
+* reference-bus angle: `constraint_theta_ref`
+* nodal power balance: `constraint_power_balance`
+* branch flow (Ohm's law): `constraint_ohms_yt_from` / `constraint_ohms_yt_to`
+* voltage-angle-difference limits: `constraint_voltage_angle_difference`
+* branch thermal limits: `constraint_thermal_limit_from` / `constraint_thermal_limit_to`
+* DC line losses: `constraint_dcline_power_losses`
+* model-voltage relations: `constraint_model_voltage`
+
+Generator limits (`pmin`/`pmax`, `qmin`/`qmax`) and bus voltage limits (`vmin`/`vmax`) are the
+usual variable bounds created by `variable_gen_power` and `variable_bus_voltage`, so the
+redispatch always stays within the physical capabilities of the generators and the voltage band.
+
+## Result
+
+`run_pandamodels_redispatch` returns the usual PowerModels result dictionary (with
+`branch_flows` enabled), containing `termination_status`, `primal_status`, `objective`,
+`solve_time` and a `solution` with the redispatched generator setpoints (`pg`, `qg`), bus
+voltages (`vm`, `va`) and branch flows (`pf`, `pt`, `qf`, `qt`). pandapower reads this back
+into the standard result tables, so `net.res_gen`/`net.res_sgen` hold the redispatched active
+powers.
+
+## API
+
+```@docs
+PandaModels._run_redispatch
+PandaModels._build_redispatch
+PandaModels._redispatch_base_pg
+```
+
+## See also
+
+* Model implementation: `src/models/redispatch.jl`
+* Call function: `run_pandamodels_redispatch` in `src/models/call_pandamodels.jl`
+* Tests: the `case_redispatch` test sets in `test/call_pandamodels.jl`

--- a/src/PandaModels.jl
+++ b/src/PandaModels.jl
@@ -35,7 +35,8 @@ export run_powermodels_pf,
     run_pandamodels_vstab_test,
     run_pandamodels_qflex_test,
     run_pandamodels_ploss_test,
-    run_pandamodels_loading
+    run_pandamodels_loading,
+    run_pandamodels_redispatch
 
 include("input/pp_to_pm.jl")
 include("input/tools.jl")
@@ -43,6 +44,7 @@ include("models/vstab.jl")
 include("models/qflex.jl")
 include("models/pflex.jl")
 include("models/ploss.jl")
+include("models/redispatch.jl")
 include("models/call_pandamodels.jl")
 include("models/call_powermodels.jl")
 include("models/run_pm_vstab_dev.jl")

--- a/src/models/call_pandamodels.jl
+++ b/src/models/call_pandamodels.jl
@@ -121,6 +121,24 @@ function run_pandamodels_loading(json_path)
 end
 
 
+function run_pandamodels_redispatch(json_path)
+    pm = load_pm_from_json(json_path)
+    active_powermodels_silence!(pm)
+    pm = check_powermodels_data!(pm)
+    model = get_model(pm["pm_model"])
+    solver = get_solver(pm)
+
+    result = _run_redispatch(
+        pm,
+        model,
+        solver,
+        setting = Dict("output" => Dict("branch_flows" => true)),
+        ext = extract_params!(pm),
+    )
+    return result
+end
+
+
 function run_pandamodels_custom(json_path)
     pm = load_pm_from_json(json_path)
     active_powermodels_silence!(pm)

--- a/src/models/redispatch.jl
+++ b/src/models/redispatch.jl
@@ -1,0 +1,102 @@
+export _run_redispatch
+
+"""
+run a simple redispatch optimization.
+
+The redispatch model uses the standard PowerModels OPF constraints (so it works for both AC and DC
+power models) but replaces the fuel-cost objective by a redispatch objective that keeps the selected
+generators close to a base dispatch pg0.
+
+The base dispatch and (in cost mode) the up/down redispatch costs are passed from pandapower in
+pm.ext:
+    - pm.ext[:base_pg]              : Dict(pm_gen_index_str => pg0)  (per unit)
+    - pm.ext[:redispatch_cost_up]   : Dict(pm_gen_index_str => cost_up)    (cost mode only)
+    - pm.ext[:redispatch_cost_down] : Dict(pm_gen_index_str => cost_down)  (cost mode only)
+
+If the up/down cost dicts are present the cost objective is used, otherwise the least-deviation
+objective (keep pg close to pg0) is used.
+"""
+function _run_redispatch(file, model_type::_PM.Type, optimizer; kwargs...)
+    return _PM.solve_model(file, model_type, optimizer, _build_redispatch; kwargs...)
+end
+
+"""
+build the redispatch optimization model (standard OPF constraints + redispatch objective)
+"""
+function _build_redispatch(pm::_PM.AbstractPowerModel)
+
+    _PM.variable_bus_voltage(pm)
+    _PM.variable_gen_power(pm)
+    _PM.variable_branch_power(pm)
+    _PM.variable_dcline_power(pm, bounded = false)
+
+    objective_redispatch(pm)
+
+    _PM.constraint_model_voltage(pm)
+
+    for i in _PM.ids(pm, :ref_buses)
+        _PM.constraint_theta_ref(pm, i)
+    end
+
+    for i in _PM.ids(pm, :bus)
+        _PM.constraint_power_balance(pm, i)
+    end
+
+    for (i, branch) in _PM.ref(pm, :branch)
+        _PM.constraint_ohms_yt_from(pm, i)
+        _PM.constraint_ohms_yt_to(pm, i)
+
+        _PM.constraint_voltage_angle_difference(pm, i)
+
+        _PM.constraint_thermal_limit_from(pm, i)
+        _PM.constraint_thermal_limit_to(pm, i)
+    end
+
+    for i in _PM.ids(pm, :dcline)
+        _PM.constraint_dcline_power_losses(pm, i)
+    end
+end
+
+"""
+returns Dict(pm_gen_index::Int => pg0) with the base dispatch of the redispatch generators
+"""
+function _redispatch_base_pg(pm::_PM.AbstractPowerModel)
+    base_pg = Dict{Int,Float64}()
+    if haskey(pm.ext, :base_pg)
+        for (k, v) in pm.ext[:base_pg]
+            base_pg[parse(Int, k)] = v
+        end
+    end
+    return base_pg
+end
+
+function objective_redispatch(pm::_PM.AbstractPowerModel)
+    base_pg = _redispatch_base_pg(pm)
+
+    # cost mode is selected implicitly by the presence of the up/down cost dicts, otherwise the
+    # least-deviation objective is used (see add_redispatch_params on the pandapower side).
+    redispatch_cost = haskey(pm.ext, :redispatch_cost_up) && haskey(pm.ext, :redispatch_cost_down)
+
+    if redispatch_cost
+        cost_up = Dict(parse(Int, k) => v for (k, v) in pm.ext[:redispatch_cost_up])
+        cost_down = Dict(parse(Int, k) => v for (k, v) in pm.ext[:redispatch_cost_down])
+
+        gen_ids = collect(keys(base_pg))
+
+        # split the redispatch of each participating generator into a non-negative upward and
+        # downward part: pg = pg0 + pg_up - pg_down
+        JuMP.@variable(pm.model, pg_up[i in gen_ids] >= 0)
+        JuMP.@variable(pm.model, pg_down[i in gen_ids] >= 0)
+
+        for i in gen_ids
+            JuMP.@constraint(pm.model, var(pm, :pg, i) == base_pg[i] + pg_up[i] - pg_down[i])
+        end
+
+        return JuMP.@objective(pm.model, Min,
+            sum(cost_up[i] * pg_up[i] + cost_down[i] * pg_down[i] for i in gen_ids))
+    else
+        # least-deviation objective: keep generators close to their base dispatch
+        return JuMP.@objective(pm.model, Min,
+            sum((var(pm, :pg, i) - pg0)^2 for (i, pg0) in base_pg))
+    end
+end

--- a/src/models/redispatch.jl
+++ b/src/models/redispatch.jl
@@ -9,7 +9,9 @@ generators close to a base dispatch pg0.
 
 The base dispatch and (in cost mode) the up/down redispatch costs are passed from pandapower in
 pm.ext:
-    - pm.ext[:base_pg]              : Dict(pm_gen_index_str => pg0)  (per unit)
+    - pm.ext[:base_pg]              : Dict(pm_gen_index_str => pg0)  (participating gens, per unit)
+    - pm.ext[:fixed_pg]             : Dict(pm_gen_index_str => pg0)  (controllable but non-priced
+                                      gens that are pinned to their base dispatch)
     - pm.ext[:redispatch_cost_up]   : Dict(pm_gen_index_str => cost_up)    (cost mode only)
     - pm.ext[:redispatch_cost_down] : Dict(pm_gen_index_str => cost_down)  (cost mode only)
 
@@ -31,6 +33,13 @@ function _build_redispatch(pm::_PM.AbstractPowerModel)
     _PM.variable_dcline_power(pm, bounded = false)
 
     objective_redispatch(pm)
+
+    # pin controllable-but-non-participating generators to their base dispatch
+    if haskey(pm.ext, :fixed_pg)
+        for (k, v) in pm.ext[:fixed_pg]
+            JuMP.@constraint(pm.model, var(pm, :pg, parse(Int, k)) == v)
+        end
+    end
 
     _PM.constraint_model_voltage(pm)
 

--- a/test/call_pandamodels.jl
+++ b/test/call_pandamodels.jl
@@ -114,4 +114,40 @@
         @test string(result["primal_status"]) == "FEASIBLE_POINT"
     end
 
+    @testset "case_redispatch: deviation" begin
+        result = run_pandamodels_redispatch(case_redispatch)
+        pm = _PdM.load_pm_from_json(case_redispatch)
+
+        @test string(result["termination_status"]) == "LOCALLY_SOLVED"
+        @test string(result["primal_status"]) == "FEASIBLE_POINT"
+
+        # the congested branch must respect its thermal limit
+        for (i, br) in result["solution"]["branch"]
+            rate_a = pm["branch"][i]["rate_a"]
+            s = sqrt(br["pf"]^2 + br["qf"]^2)
+            @test s <= rate_a + 1e-4
+        end
+
+        # base case was infeasible -> a non-zero deviation is needed
+        @test result["objective"] > 0.0
+        @test result["solve_time"] >= 0.0
+    end
+
+    @testset "case_redispatch: cost" begin
+        result = run_pandamodels_redispatch(case_redispatch_cost)
+        pm = _PdM.load_pm_from_json(case_redispatch_cost)
+
+        @test string(result["termination_status"]) == "LOCALLY_SOLVED"
+        @test string(result["primal_status"]) == "FEASIBLE_POINT"
+
+        for (i, br) in result["solution"]["branch"]
+            rate_a = pm["branch"][i]["rate_a"]
+            s = sqrt(br["pf"]^2 + br["qf"]^2)
+            @test s <= rate_a + 1e-4
+        end
+
+        @test result["objective"] >= 0.0
+        @test result["solve_time"] >= 0.0
+    end
+
 end

--- a/test/data/test_redispatch.json
+++ b/test/data/test_redispatch.json
@@ -1,0 +1,191 @@
+{
+    "ac": true,
+    "baseMVA": 1,
+    "branch": {
+        "1": {
+            "angmax": 1.0471975511965976,
+            "angmin": -1.0471975511965976,
+            "b_fr": 0.1663080610994097,
+            "b_to": 0.1663080610994097,
+            "br_r": 0.00016033057851239668,
+            "br_status": 1,
+            "br_x": 0.00033884297520661154,
+            "f_bus": 2,
+            "g_fr": 0.0,
+            "g_to": 0.0,
+            "index": 1,
+            "rate_a": 22.386756687827734,
+            "rate_b": 0.0,
+            "rate_c": 0.0,
+            "shift": 0.0,
+            "t_bus": 3,
+            "tap": 1.0,
+            "transformer": false
+        },
+        "2": {
+            "angmax": 1.0471975511965976,
+            "angmin": -1.0471975511965976,
+            "b_fr": 0.1663080610994097,
+            "b_to": 0.1663080610994097,
+            "br_r": 0.00016033057851239668,
+            "br_status": 1,
+            "br_x": 0.00033884297520661154,
+            "f_bus": 1,
+            "g_fr": 0.0,
+            "g_to": 0.0,
+            "index": 2,
+            "rate_a": 89.54702675131094,
+            "rate_b": 0.0,
+            "rate_c": 0.0,
+            "shift": 0.0,
+            "t_bus": 2,
+            "tap": 1.0,
+            "transformer": false
+        }
+    },
+    "bus": {
+        "1": {
+            "base_kv": 110.0,
+            "bus_i": 1,
+            "bus_type": 3,
+            "index": 1,
+            "va": 0.0,
+            "vm": 1.0,
+            "vmax": 1.00000001,
+            "vmin": 0.99999999,
+            "zone": 1
+        },
+        "2": {
+            "base_kv": 110.0,
+            "bus_i": 2,
+            "bus_type": 2,
+            "index": 2,
+            "va": -0.00029652465270375573,
+            "vm": 1.0,
+            "vmax": 1.1,
+            "vmin": 0.9,
+            "zone": 1
+        },
+        "3": {
+            "base_kv": 110.0,
+            "bus_i": 3,
+            "bus_type": 2,
+            "index": 3,
+            "va": -0.025329793812359266,
+            "vm": 1.0,
+            "vmax": 1.1,
+            "vmin": 0.9,
+            "zone": 1
+        }
+    },
+    "correct_pm_network_data": true,
+    "dcline": {},
+    "gen": {
+        "1": {
+            "cost": [
+                0,
+                0.0,
+                0.0
+            ],
+            "gen_bus": 1,
+            "gen_status": 1,
+            "index": 1,
+            "model": 2,
+            "ncost": 3,
+            "pg": 0.0,
+            "pg_start": 0.715072704958402,
+            "pmax": 100.00000001,
+            "pmin": -100.00000001,
+            "qg": 0.0,
+            "qg_start": -0.5045297903811843,
+            "qmax": 100.00000001,
+            "qmin": -100.00000001,
+            "shutdown": 0.0,
+            "startup": 0.0,
+            "vg": 1.0
+        },
+        "2": {
+            "cost": [
+                0,
+                1.0,
+                0.0
+            ],
+            "gen_bus": 2,
+            "gen_status": 1,
+            "index": 2,
+            "model": 2,
+            "ncost": 3,
+            "pg": 60.0,
+            "pg_start": 60.0,
+            "pmax": 100.00000001,
+            "pmin": -1e-08,
+            "qg": 0.0,
+            "qg_start": -27.798066222608206,
+            "qmax": 50.00000001,
+            "qmin": -50.00000001,
+            "shutdown": 0.0,
+            "startup": 0.0,
+            "vg": 1.0
+        },
+        "3": {
+            "cost": [
+                0,
+                1.0,
+                0.0
+            ],
+            "gen_bus": 3,
+            "gen_status": 1,
+            "index": 3,
+            "model": 2,
+            "ncost": 3,
+            "pg": 0.0,
+            "pg_start": 0.0,
+            "pmax": 100.00000001,
+            "pmin": -1e-08,
+            "qg": 0.0,
+            "qg_start": 39.148599897626525,
+            "qmax": 50.00000001,
+            "qmin": -50.00000001,
+            "shutdown": 0.0,
+            "startup": 0.0,
+            "vg": 1.0
+        }
+    },
+    "load": {
+        "1": {
+            "index": 1,
+            "load_bus": 3,
+            "pd": 60.0,
+            "qd": 10.0,
+            "status": 1
+        }
+    },
+    "name": "",
+    "ne_branch": {},
+    "per_unit": true,
+    "pm_log_level": 0,
+    "pm_mip_solver": "cbc",
+    "pm_mip_time_limit": Infinity,
+    "pm_model": "ACPPowerModel",
+    "pm_nl_solver": "ipopt",
+    "pm_nl_time_limit": Infinity,
+    "pm_solver": "ipopt",
+    "pm_time_limit": Infinity,
+    "pm_tol": 1e-08,
+    "shunt": {},
+    "silence": true,
+    "source_version": "2.0.0",
+    "sourcetype": "matpower",
+    "storage": {},
+    "switch": {},
+    "user_defined_params": {
+        "base_pg": {
+            "2": 60.0,
+            "3": 0.0
+        },
+        "gen_and_controllable_sgen": {
+            "2": 2,
+            "3": 3
+        }
+    }
+}

--- a/test/data/test_redispatch_cost.json
+++ b/test/data/test_redispatch_cost.json
@@ -1,0 +1,199 @@
+{
+    "ac": true,
+    "baseMVA": 1,
+    "branch": {
+        "1": {
+            "angmax": 1.0471975511965976,
+            "angmin": -1.0471975511965976,
+            "b_fr": 0.1663080610994097,
+            "b_to": 0.1663080610994097,
+            "br_r": 0.00016033057851239668,
+            "br_status": 1,
+            "br_x": 0.00033884297520661154,
+            "f_bus": 2,
+            "g_fr": 0.0,
+            "g_to": 0.0,
+            "index": 1,
+            "rate_a": 22.386756687827734,
+            "rate_b": 0.0,
+            "rate_c": 0.0,
+            "shift": 0.0,
+            "t_bus": 3,
+            "tap": 1.0,
+            "transformer": false
+        },
+        "2": {
+            "angmax": 1.0471975511965976,
+            "angmin": -1.0471975511965976,
+            "b_fr": 0.1663080610994097,
+            "b_to": 0.1663080610994097,
+            "br_r": 0.00016033057851239668,
+            "br_status": 1,
+            "br_x": 0.00033884297520661154,
+            "f_bus": 1,
+            "g_fr": 0.0,
+            "g_to": 0.0,
+            "index": 2,
+            "rate_a": 89.54702675131094,
+            "rate_b": 0.0,
+            "rate_c": 0.0,
+            "shift": 0.0,
+            "t_bus": 2,
+            "tap": 1.0,
+            "transformer": false
+        }
+    },
+    "bus": {
+        "1": {
+            "base_kv": 110.0,
+            "bus_i": 1,
+            "bus_type": 3,
+            "index": 1,
+            "va": 0.0,
+            "vm": 1.0,
+            "vmax": 1.00000001,
+            "vmin": 0.99999999,
+            "zone": 1
+        },
+        "2": {
+            "base_kv": 110.0,
+            "bus_i": 2,
+            "bus_type": 2,
+            "index": 2,
+            "va": -0.00029652465270375573,
+            "vm": 1.0,
+            "vmax": 1.1,
+            "vmin": 0.9,
+            "zone": 1
+        },
+        "3": {
+            "base_kv": 110.0,
+            "bus_i": 3,
+            "bus_type": 2,
+            "index": 3,
+            "va": -0.025329793812359266,
+            "vm": 1.0,
+            "vmax": 1.1,
+            "vmin": 0.9,
+            "zone": 1
+        }
+    },
+    "correct_pm_network_data": true,
+    "dcline": {},
+    "gen": {
+        "1": {
+            "cost": [
+                0,
+                0.0,
+                0.0
+            ],
+            "gen_bus": 1,
+            "gen_status": 1,
+            "index": 1,
+            "model": 2,
+            "ncost": 3,
+            "pg": 0.0,
+            "pg_start": 0.715072704958402,
+            "pmax": 100.00000001,
+            "pmin": -100.00000001,
+            "qg": 0.0,
+            "qg_start": -0.5045297903811843,
+            "qmax": 100.00000001,
+            "qmin": -100.00000001,
+            "shutdown": 0.0,
+            "startup": 0.0,
+            "vg": 1.0
+        },
+        "2": {
+            "cost": [
+                0,
+                1.0,
+                0.0
+            ],
+            "gen_bus": 2,
+            "gen_status": 1,
+            "index": 2,
+            "model": 2,
+            "ncost": 3,
+            "pg": 60.0,
+            "pg_start": 60.0,
+            "pmax": 100.00000001,
+            "pmin": -1e-08,
+            "qg": 0.0,
+            "qg_start": -27.798066222608206,
+            "qmax": 50.00000001,
+            "qmin": -50.00000001,
+            "shutdown": 0.0,
+            "startup": 0.0,
+            "vg": 1.0
+        },
+        "3": {
+            "cost": [
+                0,
+                1.0,
+                0.0
+            ],
+            "gen_bus": 3,
+            "gen_status": 1,
+            "index": 3,
+            "model": 2,
+            "ncost": 3,
+            "pg": 0.0,
+            "pg_start": 0.0,
+            "pmax": 100.00000001,
+            "pmin": -1e-08,
+            "qg": 0.0,
+            "qg_start": 39.148599897626525,
+            "qmax": 50.00000001,
+            "qmin": -50.00000001,
+            "shutdown": 0.0,
+            "startup": 0.0,
+            "vg": 1.0
+        }
+    },
+    "load": {
+        "1": {
+            "index": 1,
+            "load_bus": 3,
+            "pd": 60.0,
+            "qd": 10.0,
+            "status": 1
+        }
+    },
+    "name": "",
+    "ne_branch": {},
+    "per_unit": true,
+    "pm_log_level": 0,
+    "pm_mip_solver": "cbc",
+    "pm_mip_time_limit": Infinity,
+    "pm_model": "ACPPowerModel",
+    "pm_nl_solver": "ipopt",
+    "pm_nl_time_limit": Infinity,
+    "pm_solver": "ipopt",
+    "pm_time_limit": Infinity,
+    "pm_tol": 1e-08,
+    "shunt": {},
+    "silence": true,
+    "source_version": "2.0.0",
+    "sourcetype": "matpower",
+    "storage": {},
+    "switch": {},
+    "user_defined_params": {
+        "base_pg": {
+            "2": 60.0,
+            "3": 0.0
+        },
+        "gen_and_controllable_sgen": {
+            "2": 2,
+            "3": 3
+        },
+        "redispatch_cost_down": {
+            "2": 10.0,
+            "3": 50.0
+        },
+        "redispatch_cost_up": {
+            "2": 10.0,
+            "3": 50.0
+        }
+    }
+}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,6 +31,8 @@ case_multi_vstab = joinpath(data_path, "cigre_with_timeseries.json")
 case_multi_qflex = joinpath(data_path, "test_mn_qflex.json")
 case_multi_storage = joinpath(data_path, "test_mn_storage.json")
 case_pflex = joinpath(data_path, "test_pflex.json")
+case_redispatch = joinpath(data_path, "test_redispatch.json")
+case_redispatch_cost = joinpath(data_path, "test_redispatch_cost.json")
 
 
 


### PR DESCRIPTION
The redispatch model uses the standard PowerModels OPF constraints (so it works for both AC and DC
power models) but replaces the fuel-cost objective by a redispatch objective that keeps the selected
generators close to a base dispatch pg0.